### PR TITLE
Add Node script to convert OpenAPI schema to Swagger 2.0

### DIFF
--- a/convert-openapi-to-swagger.js
+++ b/convert-openapi-to-swagger.js
@@ -1,0 +1,56 @@
+const fs = require('fs').promises;
+const converter = require('api-spec-converter');
+
+async function convert() {
+  try {
+    const data = await fs.readFile('openapi.json', 'utf8');
+    const openapi = JSON.parse(data);
+
+    const result = await converter.convert({
+      from: 'openapi_3',
+      to: 'swagger_2',
+      source: openapi
+    });
+
+    const swagger = result.spec || result;
+
+    // Remove property servers
+    delete swagger.servers;
+
+    // Replace anyOf [string, null] with type string
+    function replaceAnyOf(obj) {
+      if (Array.isArray(obj)) {
+        obj.forEach(replaceAnyOf);
+        return;
+      }
+      if (obj && typeof obj === 'object') {
+        for (const key of Object.keys(obj)) {
+          if (key === 'anyOf') {
+            const schemas = obj[key];
+            if (Array.isArray(schemas) && schemas.length === 2) {
+              const types = schemas.map(s => s.type).sort();
+              if (types[0] === 'null' && types[1] === 'string') {
+                obj.type = 'string';
+                delete obj.anyOf;
+                continue;
+              }
+            }
+            schemas.forEach(replaceAnyOf);
+          } else {
+            replaceAnyOf(obj[key]);
+          }
+        }
+      }
+    }
+
+    replaceAnyOf(swagger);
+
+    await fs.writeFile('swagger2.json', JSON.stringify(swagger, null, 2));
+    console.log('swagger2.json gerado com sucesso!');
+  } catch (err) {
+    console.error('Falha na conversão:', err.message);
+    process.exit(1);
+  }
+}
+
+convert();

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,51 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Sample API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {"url": "https://example.com"}
+  ],
+  "paths": {
+    "/items": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "anyOf": [
+                        {"type": "string"},
+                        {"type": "null"}
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "NaturalLanguageQuery": {
+        "type": "object",
+        "properties": {
+          "contexto": {
+            "anyOf": [
+              {"type": "string"},
+              {"type": "null"}
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "dex",
+  "version": "1.0.0",
+  "description": "",
+  "main": "convert-openapi-to-swagger.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "api-spec-converter": "^2.8.4"
+  }
+}


### PR DESCRIPTION
## Summary
- add sample OpenAPI 3.1 schema and Node.js converter that produces Swagger 2.0 and strips unsupported fields
- declare api-spec-converter dependency to perform the translation
- remove earlier Python-based conversion utility

## Testing
- `npm install api-spec-converter` *(fails: 403 Forbidden - GET https://registry.npmjs.org/api-spec-converter)*
- `node convert-openapi-to-swagger.js` *(fails: Cannot find module 'api-spec-converter')*
- `python -m py_compile server.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cef92200483329f0e4c5ac4106200